### PR TITLE
Disable treesitter highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,24 @@ Here are the default configuration options:
 
 ```lua
 require('qfpreview').setup({
-    -- number | "fill"
-    -- number will set the window to a fixed height
-    -- "fill" will make the window fill the editor's remaining space
-    height = "fill",
-    -- whether to show the buffer's name
-    show_name = true,
-    -- the window's throttle time in milliseconds
-    throttle = 100,
-    -- additinonal window configuration
-    win = {}
+    ui = {
+      -- number | "fill"
+      -- number will set the window to a fixed height
+      -- "fill" will make the window fill the editor's remaining space
+      height = "fill",
+      -- whether to show the buffer's name
+      show_name = true,
+      -- additinonal window configuration
+      win = {}
+    },
+    opts = {
+      -- the window's throttle time in milliseconds
+      throttle = 100,
+      -- whether to enable lsp clients
+      lsp = true,
+      -- whether to enable diagnostics
+      diagnostics = true
+    }
 })
 ```
 

--- a/doc/qfpreview.txt
+++ b/doc/qfpreview.txt
@@ -41,17 +41,25 @@ Configuration                                          *qfpreview-configuration*
 
 Here are the default configuration options:
 >lua
-    require('qfpreview').setup({
-      -- number | "fill"
-      -- number will set the window to a fixed height
-      -- "fill" will make the window fill the editor's remaining space
-      height = "fill",
-      -- whether to show the buffer's name
-      show_name = true,
-      -- the window's throttle time in milliseconds
-      throttle = 100,
-      -- additinonal window configuration
-      win = {}
+      require('qfpreview').setup({
+      ui = {
+	-- number | "fill"
+	-- number will set the window to a fixed height
+	-- "fill" will make the window fill the editor's remaining space
+	height = "fill",
+	-- whether to show the buffer's name
+	show_name = true,
+	-- additinonal window configuration
+	win = {}
+      },
+      opts = {
+	-- the window's throttle time in milliseconds
+	throttle = 100,
+	-- whether to enable lsp clients
+	lsp = true,
+	-- whether to enable diagnostics
+	diagnostics = true
+      }
     })
 <
 

--- a/lua/qfpreview/config.lua
+++ b/lua/qfpreview/config.lua
@@ -1,0 +1,33 @@
+---@class qfpreview.Config
+---@field ui qfpreview.Config.Ui
+---@field opts qfpreview.Config.Opts
+
+---@class qfpreview.Config.Ui
+---@field height number | "fill" the height of the window
+--- number will set the window to a fixed height
+--- "fill" will make the window fill the editor's remaining space
+---@field show_name boolean whether to show the buffer's name
+---@field win vim.api.keyset.win_config additinonal window configuration
+
+---@class qfpreview.Config.Opts
+---@field throttle number the window's throttle time in milliseconds
+---@field lsp boolean whether to enable lsp clients
+---@field diagnostics boolean whether to enable diagnostics
+
+local M = {}
+
+---@type qfpreview.Config
+M.defaults = {
+  ui = {
+    height = "fill",
+    show_name = true,
+    win = {},
+  },
+  opts = {
+    throttle = 100,
+    lsp = false,
+    diagnostics = false,
+  },
+}
+
+return M

--- a/lua/qfpreview/config.lua
+++ b/lua/qfpreview/config.lua
@@ -25,7 +25,7 @@ M.defaults = {
   },
   opts = {
     throttle = 100,
-    lsp = false,
+    lsp = true,
     diagnostics = false,
   },
 }

--- a/lua/qfpreview/init.lua
+++ b/lua/qfpreview/init.lua
@@ -11,7 +11,7 @@ function M.setup(config)
   ---@param qfwin integer
   local refresh = util.throttle(function(qfwin)
     preview:refresh(qfwin)
-  end, preview.config.throttle)
+  end, preview.config.opts.throttle)
 
   ---@type integer?
   local qfwin

--- a/lua/qfpreview/preview.lua
+++ b/lua/qfpreview/preview.lua
@@ -1,3 +1,5 @@
+-- TODO: support vertically split qflist
+
 local fs = require("qfpreview.fs")
 
 ---@class qfpreview.Config
@@ -56,21 +58,6 @@ function Preview:curr_item()
   local qflist = vim.fn.getqflist()
   return qflist[vim.fn.line(".")]
 end
-
----@param item QuickfixItem
-function Preview:highlight(item)
-  if not self.parsed_bufs[item.bufnr] then
-    vim.api.nvim_buf_call(item.bufnr, function()
-      vim.cmd("filetype detect")
-      pcall(vim.treesitter.start, item.bufnr)
-    end)
-    self.parsed_bufs[item.bufnr] = true
-  end
-
-  vim.api.nvim_win_set_cursor(self.winnr, { item.lnum, item.col })
-end
-
--- TODO: support vertically split qflist
 
 ---@param qfwin number
 ---@return number,number
@@ -165,7 +152,7 @@ function Preview:open(qfwin)
   vim.wo[self.winnr].winblend = 0
   vim.wo[self.winnr].cursorline = true
 
-  self:highlight(item)
+  vim.api.nvim_win_set_cursor(self.winnr, { item.lnum, item.col })
 end
 
 function Preview:close()
@@ -195,7 +182,7 @@ function Preview:refresh(qfwin)
     vim.api.nvim_win_set_config(self.winnr, win_config)
   end
 
-  self:highlight(item)
+  vim.api.nvim_win_set_cursor(self.winnr, { item.lnum, item.col })
 end
 
 return Preview

--- a/lua/qfpreview/preview.lua
+++ b/lua/qfpreview/preview.lua
@@ -59,6 +59,21 @@ function Preview:curr_item()
   return qflist[vim.fn.line(".")]
 end
 
+---@return integer
+function Preview:bufnr()
+  return vim.api.nvim_win_get_buf(self.winnr)
+end
+
+function Preview:disable_lsp()
+  local bufnr = self:bufnr()
+
+  for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+    vim.lsp.buf_detach_client(bufnr, client.id)
+  end
+
+  vim.diagnostic.enable(false, { bufnr = bufnr })
+end
+
 ---@param qfwin number
 ---@return number,number
 local function get_aligned_col_width(qfwin)
@@ -146,6 +161,7 @@ function Preview:open(qfwin)
   end
 
   self.winnr = vim.api.nvim_open_win(item.bufnr, false, winconfig)
+  self:disable_lsp()
 
   vim.wo[self.winnr].relativenumber = false
   vim.wo[self.winnr].number = true

--- a/lua/qfpreview/preview.lua
+++ b/lua/qfpreview/preview.lua
@@ -52,11 +52,13 @@ end
 function Preview:disable_lsp()
   local bufnr = self:bufnr()
 
-  for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
-    vim.lsp.buf_detach_client(bufnr, client.id)
+  if not self.config.opts.lsp then
+    for _, client in pairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+      vim.lsp.buf_detach_client(bufnr, client.id)
+    end
   end
 
-  vim.diagnostic.enable(false, { bufnr = bufnr })
+  vim.diagnostic.enable(self.config.opts.diagnostics, { bufnr = bufnr })
 end
 
 ---@param qfwin number

--- a/lua/qfpreview/preview.lua
+++ b/lua/qfpreview/preview.lua
@@ -1,14 +1,7 @@
 -- TODO: support vertically split qflist
 
+local defaults = require("qfpreview.config").defaults
 local fs = require("qfpreview.fs")
-
----@class qfpreview.Config
----@field height number | "fill" the height of the window
---- number will set the window to a fixed height
---- "fill" will make the window fill the editor's remaining space
----@field show_name boolean whether to show the buffer's name
----@field throttle number the window's throttle time in milliseconds
----@field win vim.api.keyset.win_config additinonal window configuration
 
 ---@class qfpreview.Preview
 ---@field config qfpreview.Config
@@ -16,14 +9,6 @@ local fs = require("qfpreview.fs")
 ---@field parsed_bufs table<number, boolean>
 local Preview = {}
 Preview.__index = Preview
-
----@type qfpreview.Config
-local defaults = {
-  height = "fill",
-  show_name = true,
-  throttle = 100,
-  win = {},
-}
 
 ---@param config? qfpreview.Config
 ---@return qfpreview.Preview
@@ -101,7 +86,7 @@ function Preview:win_config(qfwin)
   local border_width = has_border and 2 or 0
   local col, width = get_aligned_col_width(qfwin)
 
-  if self.config.height == "fill" then
+  if self.config.ui.height == "fill" then
     local statusline_height = vim.o.laststatus == 0 and 0 or 1
     local height = vim.o.lines - vim.api.nvim_win_get_height(qfwin) - vim.o.cmdheight - border_width - statusline_height
 
@@ -119,7 +104,7 @@ function Preview:win_config(qfwin)
     }
   end
 
-  local height = self.config.height or 15
+  local height = self.config.ui.height or 15
 
   return {
     relative = "win",
@@ -153,9 +138,9 @@ function Preview:open(qfwin)
   local item = self:curr_item()
 
   ---@type vim.api.keyset.win_config
-  local winconfig = vim.tbl_extend("force", self:win_config(qfwin), self.config.win or {})
+  local winconfig = vim.tbl_extend("force", self:win_config(qfwin), self.config.ui.win or {})
 
-  if self.config.show_name then
+  if self.config.ui.show_name then
     winconfig.title = self:title(item.bufnr)
     winconfig.title_pos = "left"
   end
@@ -193,7 +178,7 @@ function Preview:refresh(qfwin)
   local item = self:curr_item()
 
   vim.api.nvim_win_set_buf(self.winnr, item.bufnr)
-  if self.config.show_name then
+  if self.config.ui.show_name then
     local win_config = vim.tbl_extend("force", self:win_config(qfwin), { title = self:title(item.bufnr) })
     vim.api.nvim_win_set_config(self.winnr, win_config)
   end

--- a/lua/qfpreview/preview.lua
+++ b/lua/qfpreview/preview.lua
@@ -6,7 +6,6 @@ local fs = require("qfpreview.fs")
 ---@class qfpreview.Preview
 ---@field config qfpreview.Config
 ---@field winnr number
----@field parsed_bufs table<number, boolean>
 local Preview = {}
 Preview.__index = Preview
 
@@ -16,7 +15,6 @@ function Preview:new(config)
   local p = {
     config = vim.tbl_deep_extend("force", defaults, config or {}),
     win_id = nil,
-    parsed_bufs = {},
   }
   setmetatable(p, self)
   self.__index = self


### PR DESCRIPTION
Addresses #1

- Breaking: Reorganized config into `ui` and `opts` sections.
- Remove treesitter highlighing in favor of the default highlighing + LSP semantic tokens (configurable via `opts.lsp`)
- Disable diagnostics for the preview by default (configurable via `opts.diagnostics`)
- Moved config type and defaults to their own module.
